### PR TITLE
Fix search functionality

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,4 +1,18 @@
-<script src='{{ "js/main.js" | relURL }}'></script>
+<script>
+
+    var mainJS = document.querySelector('script[src*="js/main"]');
+
+    var script = document.createElement("script");
+    script.src = mainJS.src.replace('azurestack-docs/azurestack-docs', 'azurestack-docs');
+    script.integrity = mainJS.integrity;
+    script.crossOrigin = mainJS.crossOrigin;
+
+    document.body.appendChild(script);
+
+    var offlineSearch = document.querySelector('input[data-offline-search-index-json-src*="offline-search"]');
+    offlineSearch.setAttribute('data-offline-search-index-json-src', offlineSearch.getAttribute('data-offline-search-index-json-src').replace('azurestack-docs/azurestack-docs', 'azurestack-docs'));
+
+</script>
 
 <script>
     // Credit to https://radu-matei.com/blog/dark-mode/


### PR DESCRIPTION
# Description
A couple of file sources from Docsy break when canonifyUrls is enabled with a subdomain (/azurestack-docs). 
This implements a pretty hacky method of overriding the broken src attributes.

# GitHub Issues
N/A

# Checklist:

- [x] Have you run grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [x] Have you added high-resolution images?
