### PR TITLE
Removed 23H2 upgrades warning from the 16G matrix as it was deemed un…

### DIFF
--- a/content/en/docs/hci/SupportMatrix/2409/16G_HCI/_index.md
+++ b/content/en/docs/hci/SupportMatrix/2409/16G_HCI/_index.md
@@ -54,11 +54,6 @@ Description: >
     <div id="content">
 {{< /rawhtml >}}
 
-## Notes and warnings
-{{% alert title="CAUTION" color="warning" %}}
-The update of Azure Stack HCI, version 22H2 to Azure Stack HCI, version 23H2 is currently not supported. For new deployments, we recommend that you use Azure Stack HCI, version 23H2 which is now generally available. For more information on Azure Stack HCI, version 23H2, see [Use Azure Update Manager to update your Azure Stack HCI, version 23H2](https://learn.microsoft.com/en-us/azure-stack/hci/update/azure-update-manager-23h2).
-{{% /alert %}}
-
 ### Supported Platforms
 {{< rawhtml >}}
 <table> <colgroup><col/><col/></colgroup> <tr><th>Model</th><th>Supported Operating System</th></tr> <tr><td>AX-760</td><td>Windows Server 2022 Datacenter<br>Azure Stack HCI-22H2<br>Azure Stack HCI-23H2</td></tr> </table><br>


### PR DESCRIPTION
…necessary.

# Description
- Removed the 23H2 upgrade warning from the 16G support matrix as it was deemed unnecessary.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?
