### PR TITLE
Modified the verbiage of the 23H2 upgrade warning in the 2406 14G_15G…

### DIFF
--- a/content/en/docs/hci/SupportMatrix/2406/14G-15G_HCI/_index.md
+++ b/content/en/docs/hci/SupportMatrix/2406/14G-15G_HCI/_index.md
@@ -56,7 +56,11 @@ Description: >
 
 ## Notes and warnings
 {{% alert title="CAUTION" color="warning" %}}
-The update of Azure Stack HCI, version 22H2 to Azure Stack HCI, version 23H2 is currently not supported. For new deployments, we recommend that you use Azure Stack HCI, version 23H2 which is now generally available. For more information on Azure Stack HCI, version 23H2, see [Use Azure Update Manager to update your Azure Stack HCI, version 23H2](https://learn.microsoft.com/en-us/azure-stack/hci/update/azure-update-manager-23h2).
+The upgrade of Azure Stack HCI, version 22H2 to Azure Stack HCI, version 23H2 is currently not supported by Dell. Dell customers are recommended to wait for Dell to complete the upgrade validation prior to attempting the upgrade. Customers that choose to proceed with the upgrade need to contact Microsoft for any assistance with resolving problems that may occur during the upgrade process.
+
+Dell also recommends that any customer choosing to upgrade their Azure Stack HCI clusters running HCI OS 22H2 to HCI OS 23H2 should update the cluster node to the drivers and firmware versions listed in the 2409 support matrix prior to upgrading. 
+
+For new deployments, we recommend that you use Azure Stack HCI, version 23H2 which is now generally available. For more information on Azure Stack HCI, version 23H2, see Use Azure Update Manager to update your Azure Stack HCI, version 23H2.
 {{% /alert %}}
 
 ### Supported Platforms


### PR DESCRIPTION
… HCI matrix to match the 2409 HCI 14G_15G matrix

# Description
- Changed the 23H2 verbiage of the HCI 2406 14G_15G matrix to match what is currently in the HCI 2409 14G_15G matrix. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?
