### PR TITLE
Added the Dell Controlled Turbo Setting to the list for Intel platforms

### DIFF
--- a/content/en/docs/hci/BIOSandiDRAC/_index.md
+++ b/content/en/docs/hci/BIOSandiDRAC/_index.md
@@ -57,6 +57,7 @@ The following table lists the BIOS configuration settings for server nodes imple
 |Processor Settings|Virtualization Technology|Enabled|Enabled|AX-640<br><br>AX-740xd<br><br>AX-650<br><br>AX-750<br><br>AX-6515<br><br>AX-7525<br><br>AX-760<br><br>AX-4510c<br><br>AX-4520c|
 |Processor Settings|x2APIC Mode|Enabled|Enabled|AX-640<br><br>AX-740xd<br><br>AX-650<br><br>AX-750<br><br>AX-6515<br><br>AX-7525<br><br>AX-760<br><br>AX-4510c<br><br>AX-4520c|
 |Processor Settings|NUMA Nodes Per Socket|1|4|AX-6515<br><br>AX-7525|
+|Processor Settings|Dell Controlled Turbo Setting (Optional)|Disabled|Enabled|AX-760<br><br>AX-750<br><br>AX-650<br><br>AX-4510c<br><br>AX-4520c|
 |Integrated Devices|SR-IOV Global Enable|Disabled|Enabled|AX-640<br><br>AX-740xd<br><br>AX-650<br><br>AX-750<br><br>AX-6515<br><br>AX-7525<br><br>AX-760<br><br>AX-4510c<br><br>AX-4520c|
 |System Profile Settings|Systems Profile|Performance Per Watt (DAPC)|Performance|AX-640<br><br>AX-740xd<br><br>AX-650<br><br>AX-750<br><br>AX-6515<br><br>AX-7525<br><br>AX-760<br><br>AX-4510c<br><br>AX-4520c|
 |Systems Security|TPM Security|Off|On|AX-640<br><br>AX-740xd<br><br>AX-650<br><br>AX-750<br><br>AX-6515<br><br>AX-7525<br><br>AX-760<br><br>AX-4510c<br><br>AX-4520c|


### PR DESCRIPTION
# Description
The Dell Controlled Turbo Setting, which is optional, was added to the BIOS settings list. OMIMSWAC checks for this setting as part of the compliance scan on Intel based AX platforms.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?
